### PR TITLE
Update publish_pypi.yml

### DIFF
--- a/.github/workflows/publish_pypi.yml
+++ b/.github/workflows/publish_pypi.yml
@@ -32,7 +32,7 @@ jobs:
         run: uv build
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: dist-artifacts
           path: dist/*


### PR DESCRIPTION
## Related Links

- [Deprecation notice: v3 of the artifact action](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/)

## What

- Migrate to v4 of artifact action
