### PR TITLE
ci: remove condition to clear existing labels in labeler action

### DIFF
--- a/.github/pr-labeler.yml
+++ b/.github/pr-labeler.yml
@@ -1,4 +1,4 @@
-clear-prexisting: true # Whether to remove preexisting labels from the PR in favor of the generated one
+clear-prexisting: false # Whether to remove preexisting labels from the PR in favor of the generated one
 include-title: true # Consider the PR title when adding labels
 label-for-breaking-changes: "type: breaking" # Label to be used when the message has the breaking change syntax '!:' E.g. "feat!: This break things"
 label-mapping: # Label to array of types for mapping


### PR DESCRIPTION
## Why
- Remove condition to remove pre-existing labels on PRs from `PR_validator` action

## Description
- Updated respective param in `pr-labeler.yml` 

## Other Notes
- N/A