### PR TITLE
ci: update commit message & PR title of bump action

### DIFF
--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -72,7 +72,8 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           branch: bump-version-${{ env.NEW_VERSION }}
           base: main
-          title: "Draft: Bump Version ${{ env.NEW_VERSION }}"
+          title: "release: bump v${{ env.OLD_VERSION }} to v${{ env.NEW_VERSION }}"
+          commit-message: "release: bump v${{ env.OLD_VERSION }} to v${{ env.NEW_VERSION }}"
           body: |
-            Bumps version from ${{ env.OLD_VERSION }} to ${{ env.NEW_VERSION }}.
+            Bumps version from v${{ env.OLD_VERSION }} to v${{ env.NEW_VERSION }}.
           draft: false

--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -74,6 +74,7 @@ jobs:
           base: main
           title: "release: bump v${{ env.OLD_VERSION }} to v${{ env.NEW_VERSION }}"
           commit-message: "release: bump v${{ env.OLD_VERSION }} to v${{ env.NEW_VERSION }}"
+          labels: "type: release"
           body: |
             Bumps version from v${{ env.OLD_VERSION }} to v${{ env.NEW_VERSION }}.
           draft: false

--- a/caml/core/ols.py
+++ b/caml/core/ols.py
@@ -81,7 +81,7 @@ class FastOLS:
         The estimated parameters of the model.
     vcv : np.ndarray
         The estimated variance-covariance matrix of the model parameters.
-    std_errors : np.ndarray
+    std_err : np.ndarray
         The standard errors of the estimated parameters.
     treatment_effects : dict
         The estimated treatment effects dictionary.


### PR DESCRIPTION
## Why
- To update commit message & PR title for bump action to follow conventional commit framework

## Description
- Updated `bump_version.yml` action to have title, commit, and label in line with conventional commit framework

## Other Notes
- Fix super small docstring typo in `FastOLS`
