### PR TITLE
fix: quote literals for column names in patsy formula

### DIFF
--- a/caml/core/ols.py
+++ b/caml/core/ols.py
@@ -713,23 +713,23 @@ class FastOLS:
         discrete_treatment: bool = False,
         xformula: str | None = None,
     ) -> str:
-        formula = " + ".join(Y)
+        formula = " + ".join([f"Q('{y}')" for y in Y])
 
         if discrete_treatment:
-            treatment = f"C({T})"
+            treatment = f"C(Q('{T}'))"
         else:
-            treatment = T
+            treatment = f"Q('{T}')"
 
         formula += f" ~ {treatment}"
 
         for g in G or []:
-            formula += f" + C({g})*{treatment}"
+            formula += f" + C(Q('{g}'))*{treatment}"
 
         for x in X or []:
-            formula += f" + {x}*{treatment}"
+            formula += f" + Q('{x}')*{treatment}"
 
         for w in W or []:
-            formula += f" + {w}"
+            formula += f" + Q('{w}')"
 
         if xformula:
             formula += f" {xformula}"

--- a/tests/caml/core/test_ols.py
+++ b/tests/caml/core/test_ols.py
@@ -206,11 +206,12 @@ class TestFastOLSInitialization:
         if discrete_treatment:
             assert (
                 fo.formula.replace(" ", "")
-                == "Y1+Y2~C(T)+C(G1)*C(T)+C(G2)*C(T)+X1*C(T)+W1+W1**2"
+                == "Q('Y1')+Q('Y2')~C(Q('T'))+C(Q('G1'))*C(Q('T'))+C(Q('G2'))*C(Q('T'))+Q('X1')*C(Q('T'))+Q('W1')+W1**2"
             )
         else:
             assert (
-                fo.formula.replace(" ", "") == "Y1+Y2~T+C(G1)*T+C(G2)*T+X1*T+W1+W1**2"
+                fo.formula.replace(" ", "")
+                == "Q('Y1')+Q('Y2')~Q('T')+C(Q('G1'))*Q('T')+C(Q('G2'))*Q('T')+Q('X1')*Q('T')+Q('W1')+W1**2"
             )
 
         summary = (


### PR DESCRIPTION
## Why
- Make formula creation in `FastOLS` robust to special characters in column names via [quote literals](https://patsy.readthedocs.io/en/latest/builtins-reference.html#patsy.builtins.Q)

## Description
- Wrap all features names in `Q`  in patsy formula for `FastOLS` 

## Other Notes
- N/A
