### PR TITLE
docs: versioned docs framework

### DIFF
--- a/.github/workflows/bump_version.yml
+++ b/.github/workflows/bump_version.yml
@@ -78,3 +78,24 @@ jobs:
           body: |
             Bumps version from v${{ env.OLD_VERSION }} to v${{ env.NEW_VERSION }}.
           draft: false
+
+      - name: Checkout api-docs branch
+        uses: actions/checkout@v4
+        with:
+          ref: api-docs
+
+      - name: Create Previous Version Doc Snapshot
+        if: env.type != 'skip'
+        shell: bash -l {0}
+        run: |
+          source .venv/bin/activate
+          python manage_version.py add --version ${{ env.OLD_VERSION }} --from latest
+
+      - name: Commit and Push
+        if: env.type != 'skip'
+        run: |
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "github-actions[bot]"
+          git add ${{ env.OLD_VERSION }}
+          git commit -m "Create doc snapshot for v${{ env.OLD_VERSION }}"
+          git push origin api-docs

--- a/.github/workflows/create_release_tag_and_docs.yml
+++ b/.github/workflows/create_release_tag_and_docs.yml
@@ -1,0 +1,86 @@
+name: Create Release Tag & Build Release Docs
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+permissions:
+  contents: write
+  pull-requests: read
+  pages: write
+  id-token: write
+
+jobs:
+  create_tag:
+    if: >
+      github.event.pull_request.merged == true &&
+      contains(join(github.event.pull_request.labels.*.name, ','), 'type: release')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout 🛎️
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Get Current Version
+        id: get_version
+        run: |
+          VERSION=$(bump-my-version show current_version)
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+
+      - name: Create and push tag
+        run: |
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "github-actions[bot]"
+          git tag -a "v${{ steps.get_version.outputs.version }}" -m "Release version ${{ steps.get_version.outputs.version }}"
+          git push origin "v${{ steps.get_version.outputs.version }}"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@0c5e2b8115b80b4c7c5ddf6ffdd634974642d182
+        with:
+          version: ${{ vars.UV_VERSION }}
+
+      - name: Create environment
+        run: uv sync --all-groups --frozen
+
+      - name: Render Release Docs
+        id: render_docs
+        shell: bash -l {0}
+        run: |
+          set -e
+          source .venv/bin/activate
+          bash docs/marimo_examples_to_quarto.sh
+          quartodoc build --config docs/_quarto.yml
+
+          VERSION=$(bump-my-version show current_version)
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          quarto render docs/ --output-dir ../$VERSION
+
+      - name: Checkout api-docs branch
+        uses: actions/checkout@v4
+        with:
+          ref: api-docs
+
+      - name: Build API Docs
+        run: |
+          rm _site/ -r
+          mv $VERSION _site/ -r
+          cp versions.json v0* dev _site -r
+
+      - name: Commit and push dev & _site directory
+        run: |
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "github-actions[bot]"
+          git add _site/
+          git commit -m "Update _site directory"
+          git push origin api-docs
+
+      - name: Upload Artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: "_site"
+
+      - name: Deploy to Github Pages 🚀
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,10 +2,8 @@ name: Build & Publish Docs
 
 on:
   workflow_dispatch:
-
-  ## Revisit version controlling docs before auto building
-  # push:
-  #   branches: ["main"]
+  push:
+    branches: ["main"]
 
 permissions:
   contents: read
@@ -35,15 +33,28 @@ jobs:
           source .venv/bin/activate
           bash docs/marimo_examples_to_quarto.sh
           quartodoc build --config docs/_quarto.yml
-          quarto render docs/
+          quarto render docs/ --output-dir ../dev
 
-      - name: Write CNAME file
-        run: echo "caml-docs.com" > docs/_site/CNAME
+      - name: Checkout api-docs branch
+        uses: actions/checkout@v4
+        with:
+          ref: api-docs
+
+      - name: Copy dev into _site directory
+        run: cp dev versions.json _site/ -r
+
+      - name: Commit and push dev & _site directory
+        run: |
+          git config --global user.email "github-actions[bot]@users.noreply.github.com"
+          git config --global user.name "github-actions[bot]"
+          git add dev _site
+          git commit -m "Update dev directory"
+          git push origin api-docs
 
       - name: Upload Artifact
         uses: actions/upload-pages-artifact@v3
         with:
-          path: "docs/_site"
+          path: "_site"
 
       - name: Deploy to Github Pages 🚀
         id: deployment

--- a/docs/_quarto.yml
+++ b/docs/_quarto.yml
@@ -10,6 +10,7 @@ format:
     css: styles/styles.css
     toc: true
     table-scroll: true
+    include-in-header: version-switcher.html
 
 website:
   title: CaML - Causal ML

--- a/docs/version-switcher.html
+++ b/docs/version-switcher.html
@@ -1,0 +1,440 @@
+<script type="text/javascript">
+    // Enhanced Version Switcher for Quarto Documentation
+    // Provides a floating version selector with hover functionality
+
+    (function () {
+        "use strict";
+
+        // Configuration
+        const CONFIG = {
+            containerId: "version-switcher",
+            position: { bottom: "20px", right: "20px" },
+            versionsJsonPath: getVersionsJsonPath(),
+            currentVersionText: getCurrentVersionFromPath(),
+        };
+
+        // Utility function to get the correct path to versions.json
+        function getVersionsJsonPath() {
+            const path = window.location.pathname;
+            const segments = path.split("/").filter(Boolean);
+
+            return "/versions.json";
+        }
+
+        // Detect current version from URL path
+        function getCurrentVersionFromPath() {
+            const path = window.location.pathname;
+            const versionMatch = path.match(/\/v[\d\.\-\w]+\//);
+
+            if (versionMatch) {
+                return versionMatch[0].replace(/\//g, "");
+            }
+            if (path.includes("dev")) {
+                return "dev";
+            }
+
+            return "latest";
+        }
+
+        // Create version switcher HTML structure
+        function createVersionSwitcher(versions) {
+            const container = document.createElement("div");
+            container.id = CONFIG.containerId;
+            container.setAttribute("role", "navigation");
+            container.setAttribute("aria-label", "Version selector");
+
+            // Create toggle button
+            const toggleButton = document.createElement("button");
+            toggleButton.className = "version-toggle-btn";
+            toggleButton.setAttribute("aria-haspopup", "true");
+            toggleButton.setAttribute("aria-expanded", "false");
+            toggleButton.setAttribute(
+                "aria-label",
+                "Select documentation version",
+            );
+
+            const currentVersionLabel = versions.find(
+                (v) =>
+                    v.text === CONFIG.currentVersionText ||
+                    (v.text === "latest" &&
+                        CONFIG.currentVersionText === "latest"),
+            );
+
+            toggleButton.innerHTML = `
+            <span class="version-icon">📚</span>
+            <span class="version-text">${currentVersionLabel ? currentVersionLabel.text : "Version"}</span>
+            <span class="version-arrow">▼</span>
+        `;
+
+            // Create dropdown menu
+            const dropdown = document.createElement("div");
+            dropdown.className = "version-dropdown";
+            dropdown.setAttribute("role", "menu");
+            dropdown.style.display = "none";
+
+            // Create version list
+            const versionList = document.createElement("ul");
+            versionList.className = "version-list";
+            versionList.setAttribute("role", "none");
+
+            versions.forEach((version, index) => {
+                const listItem = document.createElement("li");
+                listItem.setAttribute("role", "none");
+
+                const link = document.createElement("a");
+                link.className = "version-link";
+                link.href = version.href;
+                link.textContent = version.text;
+                link.setAttribute("role", "menuitem");
+                link.setAttribute("tabindex", "-1");
+
+                // Mark current version
+                if (
+                    version.text === CONFIG.currentVersionText ||
+                    (version.text === "latest" &&
+                        CONFIG.currentVersionText === "latest")
+                ) {
+                    link.classList.add("current-version");
+                    link.setAttribute("aria-current", "page");
+                }
+
+                listItem.appendChild(link);
+                versionList.appendChild(listItem);
+            });
+
+            dropdown.appendChild(versionList);
+            container.appendChild(toggleButton);
+            container.appendChild(dropdown);
+
+            return { container, toggleButton, dropdown, versionList };
+        }
+
+        // Add event listeners for interaction
+        function addEventListeners(elements) {
+            const { container, toggleButton, dropdown, versionList } = elements;
+            let isOpen = false;
+            let hoverTimeout;
+
+            // Mouse enter - show dropdown
+            container.addEventListener("mouseenter", () => {
+                clearTimeout(hoverTimeout);
+                showDropdown();
+            });
+
+            // Mouse leave - hide dropdown with delay
+            container.addEventListener("mouseleave", () => {
+                hoverTimeout = setTimeout(() => {
+                    hideDropdown();
+                }, 300);
+            });
+
+            // Click handler for toggle button
+            toggleButton.addEventListener("click", (e) => {
+                e.preventDefault();
+                if (isOpen) {
+                    hideDropdown();
+                } else {
+                    showDropdown();
+                }
+            });
+
+            // Keyboard navigation
+            container.addEventListener("keydown", (e) => {
+                const links = versionList.querySelectorAll(".version-link");
+                const currentFocus = document.activeElement;
+                const currentIndex = Array.from(links).indexOf(currentFocus);
+
+                switch (e.key) {
+                    case "Escape":
+                        hideDropdown();
+                        toggleButton.focus();
+                        break;
+                    case "ArrowDown":
+                        e.preventDefault();
+                        if (!isOpen) {
+                            showDropdown();
+                            links[0]?.focus();
+                        } else {
+                            const nextIndex =
+                                currentIndex < links.length - 1
+                                    ? currentIndex + 1
+                                    : 0;
+                            links[nextIndex]?.focus();
+                        }
+                        break;
+                    case "ArrowUp":
+                        e.preventDefault();
+                        if (isOpen) {
+                            const prevIndex =
+                                currentIndex > 0
+                                    ? currentIndex - 1
+                                    : links.length - 1;
+                            links[prevIndex]?.focus();
+                        }
+                        break;
+                    case "Enter":
+                    case " ":
+                        if (currentFocus === toggleButton) {
+                            e.preventDefault();
+                            if (isOpen) {
+                                hideDropdown();
+                            } else {
+                                showDropdown();
+                                links[0]?.focus();
+                            }
+                        }
+                        break;
+                }
+            });
+
+            // Click outside to close
+            document.addEventListener("click", (e) => {
+                if (!container.contains(e.target)) {
+                    hideDropdown();
+                }
+            });
+
+            function showDropdown() {
+                dropdown.style.display = "block";
+                toggleButton.setAttribute("aria-expanded", "true");
+                toggleButton.classList.add("active");
+                isOpen = true;
+
+                // Animate in
+                requestAnimationFrame(() => {
+                    dropdown.style.opacity = "1";
+                    dropdown.style.transform = "translateY(0)";
+                });
+            }
+
+            function hideDropdown() {
+                dropdown.style.opacity = "0";
+                dropdown.style.transform = "translateY(-10px)";
+                toggleButton.setAttribute("aria-expanded", "false");
+                toggleButton.classList.remove("active");
+                isOpen = false;
+
+                setTimeout(() => {
+                    dropdown.style.display = "none";
+                }, 200);
+            }
+        }
+
+        // Apply CSS styles
+        function injectStyles() {
+            const styleId = "version-switcher-styles";
+            if (document.getElementById(styleId)) return;
+
+            const styles = `
+            #version-switcher {
+                position: fixed;
+                bottom: ${CONFIG.position.bottom};
+                right: ${CONFIG.position.right};
+                z-index: 9999;
+                font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif;
+                font-size: 14px;
+            }
+
+            .version-toggle-btn {
+                display: flex;
+                align-items: center;
+                gap: 8px;
+                background: rgba(255, 255, 255, 0.95);
+                border: 1px solid rgba(0, 0, 0, 0.1);
+                border-radius: 8px;
+                padding: 10px 16px;
+                cursor: pointer;
+                box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
+                backdrop-filter: blur(10px);
+                transition: all 0.2s ease;
+                color: #333;
+                font-weight: 500;
+                min-width: 120px;
+            }
+
+            .version-toggle-btn:hover {
+                background: rgba(255, 255, 255, 1);
+                box-shadow: 0 6px 20px rgba(0, 0, 0, 0.2);
+                transform: translateY(-2px);
+                border-color: rgba(0, 109, 9, 0.3);
+            }
+
+            .version-toggle-btn.active {
+                background: rgba(255, 255, 255, 1);
+                border-color: #006d09;
+            }
+
+            .version-icon {
+                font-size: 16px;
+            }
+
+            .version-text {
+                flex: 1;
+                text-align: left;
+            }
+
+            .version-arrow {
+                transition: transform 0.2s ease;
+                font-size: 12px;
+                color: #666;
+            }
+
+            .version-toggle-btn.active .version-arrow {
+                transform: rotate(180deg);
+            }
+
+            .version-dropdown {
+                position: absolute;
+                bottom: 100%;
+                right: 0;
+                margin-bottom: 8px;
+                background: rgba(255, 255, 255, 0.98);
+                border: 1px solid rgba(0, 0, 0, 0.1);
+                border-radius: 8px;
+                box-shadow: 0 8px 24px rgba(0, 0, 0, 0.2);
+                backdrop-filter: blur(10px);
+                opacity: 0;
+                transform: translateY(-10px);
+                transition: all 0.2s ease;
+                min-width: 160px;
+            }
+
+            .version-list {
+                list-style: none;
+                margin: 0;
+                padding: 8px 0;
+            }
+
+            .version-link {
+                display: block;
+                padding: 10px 16px;
+                color: #333;
+                text-decoration: none;
+                transition: all 0.15s ease;
+                position: relative;
+            }
+
+            .version-link:hover,
+            .version-link:focus {
+                background: rgba(0, 109, 9, 0.1);
+                color: #006d09;
+                outline: none;
+            }
+
+            .version-link.current-version {
+                background: rgba(0, 109, 9, 0.1);
+                color: #006d09;
+                font-weight: 600;
+            }
+
+            .version-link.current-version::after {
+                content: '✓';
+                position: absolute;
+                right: 16px;
+                top: 50%;
+                transform: translateY(-50%);
+                font-size: 12px;
+            }
+
+            /* Dark mode support */
+            @media (prefers-color-scheme: dark) {
+                .version-toggle-btn {
+                    background: rgba(40, 40, 40, 0.95);
+                    border-color: rgba(255, 255, 255, 0.2);
+                    color: #e0e0e0;
+                }
+
+                .version-toggle-btn:hover {
+                    background: rgba(50, 50, 50, 1);
+                    border-color: rgba(0, 180, 15, 0.5);
+                }
+
+                .version-dropdown {
+                    background: rgba(40, 40, 40, 0.98);
+                    border-color: rgba(255, 255, 255, 0.2);
+                }
+
+                .version-link {
+                    color: #e0e0e0;
+                }
+
+                .version-link:hover,
+                .version-link:focus {
+                    background: rgba(0, 180, 15, 0.2);
+                    color: #00b80f;
+                }
+
+                .version-link.current-version {
+                    background: rgba(0, 180, 15, 0.2);
+                    color: #00b80f;
+                }
+            }
+
+            /* Mobile responsive */
+            @media (max-width: 768px) {
+                #version-switcher {
+                    bottom: 15px;
+                    right: 15px;
+                }
+
+                .version-toggle-btn {
+                    padding: 8px 12px;
+                    min-width: 100px;
+                    font-size: 13px;
+                }
+
+                .version-dropdown {
+                    min-width: 140px;
+                }
+
+                .version-link {
+                    padding: 8px 12px;
+                    font-size: 13px;
+                }
+            }
+        `;
+
+            const styleElement = document.createElement("style");
+            styleElement.id = styleId;
+            styleElement.textContent = styles;
+            document.head.appendChild(styleElement);
+        }
+
+        // Initialize the version switcher
+        function init() {
+            // Don't initialize if already exists
+            if (document.getElementById(CONFIG.containerId)) return;
+
+            fetch(CONFIG.versionsJsonPath)
+                .then((response) => {
+                    if (!response.ok) {
+                        throw new Error(
+                            `HTTP error! status: ${response.status}`,
+                        );
+                    }
+                    return response.json();
+                })
+                .then((versions) => {
+                    if (!Array.isArray(versions) || versions.length === 0) {
+                        console.warn("No versions found in versions.json");
+                        return;
+                    }
+
+                    injectStyles();
+                    const elements = createVersionSwitcher(versions);
+                    addEventListeners(elements);
+                    document.body.appendChild(elements.container);
+                })
+                .catch((error) => {
+                    console.warn("Failed to load version switcher:", error);
+                });
+        }
+
+        // Initialize when DOM is ready
+        if (document.readyState === "loading") {
+            document.addEventListener("DOMContentLoaded", init);
+        } else {
+            init();
+        }
+    })();
+</script>


### PR DESCRIPTION
## Why
- Enable versioning of API docs with quartodoc (a bit hacky for now) and automated commit tagging on version bumps 

## Description
- Created *api-docs* branch for managing doc snapshots
- Modified *docs.yml* to update docs for dev version (whatever is available on main) on pushes into main & commit changes to *api-docs* branch
- Modified *bump_version.yml* to capture snapshot of previous version to *api-docs* branch when bumping
- Created *create_release_tag_and_docs.yml* to tag release commit, build & publish docs based on newest version, and commit to *api-docs* branch
- Created `version-switcher.html` for custom component on api docs

## Other Notes
- N/A
