### PR TITLE
ci: turn off typeguard & enable pyright

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,7 +22,7 @@ jobs:
           python-version: "3.10"
 
       - name: Create environment
-        run: uv sync --all-groups --frozen
+        run: uv sync --all-groups --all-extras --frozen
 
       - name: Run pre-commit checks
         shell: bash -l {0}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,5 +19,9 @@ repos:
 
       - id: ruff-format
         types_or: [python, pyi, jupyter]
+  - repo: https://github.com/RobertCraigie/pyright-python
+    rev: v1.1.402
+    hooks:
+      - id: pyright
 
 exclude: ^docs/

--- a/caml/core/_base.py
+++ b/caml/core/_base.py
@@ -133,11 +133,11 @@ class CamlBase(metaclass=abc.ABCMeta):
         validation_size = int(validation_size * X.shape[0])
         test_size = int(test_size * X.shape[0])
 
-        if sample_fraction != 1.0:
-            X = X.sample(frac=sample_fraction, random_state=self.seed)
-            W = W.loc[X.index]
-            Y = Y.loc[X.index]
-            T = T.loc[X.index]
+        # if sample_fraction != 1.0:
+        #     X = X.sample(frac=sample_fraction, random_state=self.seed)
+        #     W = W.loc[X.index]
+        #     Y = Y.loc[X.index]
+        #     T = T.loc[X.index]
 
         X_train, X_test, W_train, W_test, T_train, T_test, Y_train, Y_test = (
             train_test_split(X, W, T, Y, test_size=test_size, random_state=self.seed)
@@ -253,7 +253,7 @@ class CamlBase(metaclass=abc.ABCMeta):
 
         automl.fit(feature_matrix, outcome.ravel(), **_flaml_kwargs)
 
-        model = automl.model.estimator
+        model = automl.model.estimator  # pyright: ignore[reportOptionalMemberAccess]
 
         return model
 

--- a/caml/core/_base.py
+++ b/caml/core/_base.py
@@ -1,13 +1,13 @@
 from __future__ import annotations
 
 import abc
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Iterable
 
 import numpy as np
 import pandas
+from econml._cate_estimator import BaseCateEstimator
 from flaml import AutoML
 from sklearn.model_selection import train_test_split
-from typeguard import typechecked
 
 # Optional dependencies
 try:
@@ -19,23 +19,36 @@ except ImportError:
 
 try:
     import pyspark  # noqa: F401
-    # from pyspark.sql import SparkSession
 
     _HAS_PYSPARK = True
 except ImportError:
     _HAS_PYSPARK = False
 
 if TYPE_CHECKING:
-    pass
+    import polars
+    import pyspark
 
 
-@typechecked
 class CamlBase(metaclass=abc.ABCMeta):
     """
     Base ABC class for core Caml classes.
 
     This class contains the shared methods and properties for the Caml classes.
     """
+
+    df: pandas.DataFrame
+    _validation_estimator: BaseCateEstimator
+    _final_estimator: BaseCateEstimator
+    X: Iterable[str]
+    W: Iterable[str] | None
+    T: str
+    Y: str
+    _X: np.ndarray
+    _W: np.ndarray
+    _T: np.ndarray
+    _Y: np.ndarray
+    seed: int | None
+    _data_backend: str
 
     def __init__(self):
         self._data_backend = (
@@ -45,7 +58,7 @@ class CamlBase(metaclass=abc.ABCMeta):
             if _HAS_POLARS and isinstance(self.df, polars.DataFrame)
             else "pyspark"
             if _HAS_PYSPARK
-            and isinstance(self.df, (pyspark.sql.DataFrame, pyspark.pandas.DataFrame))
+            and isinstance(self.df, (pyspark.sql.DataFrame, pyspark.pandas.DataFrame))  # type: ignore[reportAttributeAccessIssue]
             else "unknown"
         )
 

--- a/caml/core/cate.py
+++ b/caml/core/cate.py
@@ -12,7 +12,6 @@ from econml.dml import LinearDML
 from econml.score import EnsembleCateEstimator, RScorer
 from econml.validate.drtester import DRTester
 from joblib import Parallel, delayed
-from typeguard import typechecked
 
 from ..generics import experimental
 from ..logging import ERROR, INFO, WARNING
@@ -41,7 +40,6 @@ if TYPE_CHECKING:
 
 
 @experimental
-@typechecked
 class CamlCATE(CamlBase):
     r"""The CamlCATE class represents an opinionated framework of Causal Machine Learning techniques for estimating highly accurate conditional average treatment effects (CATEs).
 

--- a/caml/core/modeling/model_bank.py
+++ b/caml/core/modeling/model_bank.py
@@ -1,3 +1,4 @@
+# pyright: reportArgumentType=false
 import logging
 
 from econml._cate_estimator import BaseCateEstimator
@@ -6,7 +7,6 @@ from econml.dr import DRLearner, ForestDRLearner, LinearDRLearner
 from econml.metalearners import DomainAdaptationLearner, SLearner, TLearner, XLearner
 from sklearn.base import BaseEstimator
 from sklearn.preprocessing import PolynomialFeatures
-from typeguard import typechecked
 
 logger = logging.getLogger(__name__)
 
@@ -26,7 +26,6 @@ valid_models = [
 ]
 
 
-@typechecked
 def get_cate_model(
     model: str,
     mod_Y_X: BaseEstimator,

--- a/caml/core/ols.py
+++ b/caml/core/ols.py
@@ -1,4 +1,4 @@
-from typing import Collection, Iterable
+from typing import Any, Collection, NoReturn
 
 import pandas as pd
 import patsy
@@ -174,7 +174,7 @@ class FastOLS:
         self._formula = self.formula
         DEBUG(f"Created formula: {self.formula}")
         self._fitted = False
-        self._treatment_effects = {}
+        self._treatment_effects: Any = {}
 
     def fit(
         self,
@@ -221,7 +221,7 @@ class FastOLS:
         self._fit(X, y, cov_type=cov_type)
         self._fitted = True
         if estimate_effects:
-            diff_matrix = self._create_design_matrix(pd_df, create_diff_matrix=True)
+            diff_matrix = self._create_difference_matrix(pd_df)
             self._treatment_effects = self.estimate_ate(
                 pd_df,
                 _diff_matrix=diff_matrix,
@@ -296,11 +296,10 @@ class FastOLS:
         if not self._fitted:
             raise RuntimeError("Model must be fitted before estimating ATEs.")
 
+        pd_df = self._convert_dataframe_to_pandas(df, self.G)
         if _diff_matrix is None:
-            pd_df = self._convert_dataframe_to_pandas(df, self.G)
-            diff_matrix = self._create_design_matrix(pd_df, create_diff_matrix=True)
+            diff_matrix = self._create_difference_matrix(pd_df)
         else:
-            pd_df = df
             diff_matrix = _diff_matrix
 
         n_treated = int(pd_df[self.T].sum()) if self._discrete_treatment else None
@@ -366,7 +365,7 @@ class FastOLS:
             raise RuntimeError("Model must be fitted before estimating ATEs.")
 
         pd_df = self._convert_dataframe_to_pandas(df, self.G)
-        diff_matrix = self._create_design_matrix(pd_df, create_diff_matrix=True)
+        diff_matrix = self._create_difference_matrix(pd_df)
 
         effects = self._compute_effects(
             diff_matrix,
@@ -428,7 +427,8 @@ class FastOLS:
         if mode == "cate":
             return self.estimate_cate(df, return_results_dict=return_results_dict)
         elif mode == "outcome":
-            _, X = self._create_design_matrix(df)
+            pd_df = self._convert_dataframe_to_pandas(df, self.G)
+            _, X = self._create_design_matrix(pd_df)
             return X @ self.params
         else:
             raise ValueError(
@@ -464,12 +464,15 @@ class FastOLS:
         ```
         """
         if effects is None:
-            effects = self._treatment_effects
+            effects_to_prettify = self._treatment_effects
+        else:
+            effects_to_prettify = effects
+
         n_outcomes = len(self.Y)
 
         final_results = {}
 
-        for i, k in enumerate(effects.keys()):
+        for i, k in enumerate(effects_to_prettify.keys()):
             try:
                 group = k.split("-")[0]
                 membership = k.split("-")[1]
@@ -479,7 +482,7 @@ class FastOLS:
             if i == 0:
                 final_results["group"] = [group] * n_outcomes
                 final_results["membership"] = [membership] * n_outcomes
-                for stat, value in effects[k].items():
+                for stat, value in effects_to_prettify[k].items():
                     if isinstance(value, list):
                         final_results[stat] = value.copy()
                     elif isinstance(value, jnp.ndarray):
@@ -489,7 +492,7 @@ class FastOLS:
             else:
                 final_results["group"] += [group] * n_outcomes
                 final_results["membership"] += [membership] * n_outcomes
-                for stat, value in effects[k].items():
+                for stat, value in effects_to_prettify[k].items():
                     if isinstance(value, list):
                         final_results[stat] += value
                     elif isinstance(value, jnp.ndarray):
@@ -537,57 +540,72 @@ class FastOLS:
 
     @timer("Design Matrix Creation")
     def _create_design_matrix(
-        self, df: pd.DataFrame, create_diff_matrix: bool = False
-    ) -> jnp.ndarray | tuple[jnp.ndarray, jnp.ndarray] | None:
+        self, df: pd.DataFrame
+    ) -> tuple[jnp.ndarray, jnp.ndarray] | NoReturn:
         try:
-            if not create_diff_matrix:
-                DEBUG("Creating model matrix...")
-                y, X = patsy.dmatrices(self.formula, data=df, NA_action="raise")
+            DEBUG("Creating model design matrix...")
+            y, X = patsy.dmatrices(self.formula, data=df, NA_action="raise")  # type: ignore
 
-                self._X_design_info = X.design_info
+            self._X_design_info = X.design_info
 
-                if _HAS_JAX:
-                    y = jnp.array(y, device=jax.devices(self._engine)[0])
-                    X = jnp.array(X, device=jax.devices(self._engine)[0])
-                else:
-                    y = jnp.array(y)
-                    X = jnp.array(X)
-
-                return y, X
+            if _HAS_JAX:
+                y = jnp.array(y, device=jax.devices(self._engine)[0])  # type: ignore
+                X = jnp.array(X, device=jax.devices(self._engine)[0])  # type: ignore
             else:
-                DEBUG("Creating treatment difference matrix...")
-                original_t = df[self.T].copy()
-                if self._X_design_info is None:
-                    y, X = patsy.dmatrices(self.formula, data=df, NA_action="raise")
-                    self._X_design_info = X.design_info
+                y = jnp.array(y)
+                X = jnp.array(X)
 
-                if self._discrete_treatment:
-                    df[self.T] = 0
-                    X0 = patsy.dmatrix(self._X_design_info, data=df, NA_action="raise")
-                    df[self.T] = 1
-                    X1 = patsy.dmatrix(self._X_design_info, data=df, NA_action="raise")
-                else:
-                    X0 = patsy.dmatrix(self._X_design_info, data=df, NA_action="raise")
-                    df[self.T] = df[self.T] + 1
-                    X1 = patsy.dmatrix(self._X_design_info, data=df, NA_action="raise")
-
-                df[self.T] = original_t
-
-                if _HAS_JAX:
-                    X1 = jnp.array(X1, device=jax.devices(self._engine)[0])
-                    X0 = jnp.array(X0, device=jax.devices(self._engine)[0])
-                else:
-                    X1 = jnp.array(X1)
-                    X0 = jnp.array(X0)
-
-                diff = X1 - X0
-
-                return diff
+            return y, X
         except patsy.PatsyError as e:
             if "factor contains missing values" in str(e):
                 raise ValueError(
                     "Input DataFrame contains missing values. Please handle missing values before proceeding."
                 )
+            else:
+                raise e
+        except Exception as e:
+            raise e
+
+    @timer("Difference Matrix Creation")
+    def _create_difference_matrix(self, df: pd.DataFrame) -> jnp.ndarray | NoReturn:
+        try:
+            DEBUG("Creating treatment difference matrix...")
+            original_t = df[self.T].copy()
+            if self._X_design_info is None:
+                y, X = patsy.dmatrices(self.formula, data=df, NA_action="raise")  # type: ignore
+                self._X_design_info = X.design_info
+
+            if self._discrete_treatment:
+                df[self.T] = 0
+                X0 = patsy.dmatrix(self._X_design_info, data=df, NA_action="raise")  # type: ignore
+                df[self.T] = 1
+                X1 = patsy.dmatrix(self._X_design_info, data=df, NA_action="raise")  # type: ignore
+            else:
+                X0 = patsy.dmatrix(self._X_design_info, data=df, NA_action="raise")  # type: ignore
+                df[self.T] = df[self.T] + 1
+                X1 = patsy.dmatrix(self._X_design_info, data=df, NA_action="raise")  # type: ignore
+
+            df[self.T] = original_t
+
+            if _HAS_JAX:
+                X1 = jnp.array(X1, device=jax.devices(self._engine)[0])  # type: ignore
+                X0 = jnp.array(X0, device=jax.devices(self._engine)[0])  # type: ignore
+            else:
+                X1 = jnp.array(X1)
+                X0 = jnp.array(X0)
+
+            diff = X1 - X0
+
+            return diff
+        except patsy.PatsyError as e:
+            if "factor contains missing values" in str(e):
+                raise ValueError(
+                    "Input DataFrame contains missing values. Please handle missing values before proceeding."
+                )
+            else:
+                raise e
+        except Exception as e:
+            raise e
 
     @staticmethod
     def _compute_effects(
@@ -676,7 +694,7 @@ class FastOLS:
             return group_key, effects
 
         DEBUG(f"Starting parallel processing with {n_jobs} jobs")
-        results: Iterable = Parallel(n_jobs=n_jobs, prefer="threads")(
+        results: Any = Parallel(n_jobs=n_jobs, prefer="threads")(
             delayed(process_group)(group_key, mask, treated_mask)
             for group_key, mask, treated_mask in group_info
         )

--- a/caml/core/ols.py
+++ b/caml/core/ols.py
@@ -3,7 +3,6 @@ from typing import Collection, Iterable
 import pandas as pd
 import patsy
 from joblib import Parallel, delayed
-from typeguard import typechecked
 
 from ..generics import (
     FittedAttr,
@@ -29,7 +28,6 @@ except ImportError:
 
 
 @experimental
-@typechecked
 class FastOLS:
     r"""FastOLS is an optimized implementation of the OLS estimator designed specifically with treatment effect estimation in mind.
 
@@ -540,7 +538,7 @@ class FastOLS:
     @timer("Design Matrix Creation")
     def _create_design_matrix(
         self, df: pd.DataFrame, create_diff_matrix: bool = False
-    ) -> jnp.ndarray | tuple[jnp.ndarray, jnp.ndarray]:
+    ) -> jnp.ndarray | tuple[jnp.ndarray, jnp.ndarray] | None:
         try:
             if not create_diff_matrix:
                 DEBUG("Creating model matrix...")

--- a/caml/extensions/plots.py
+++ b/caml/extensions/plots.py
@@ -1,5 +1,6 @@
 import matplotlib.pyplot as plt
 import numpy as np
+from matplotlib.figure import Figure
 from numpy.typing import ArrayLike
 from scipy.stats import norm
 
@@ -12,7 +13,7 @@ def cate_histogram_plot(
     true_cates: ArrayLike | None = None,
     figure_kwargs: dict = {},
     hist_kwargs: dict = {},
-) -> plt.Figure:
+) -> Figure:
     """
     Plots a histogram the estimated CATEs.
 
@@ -92,7 +93,7 @@ def cate_true_vs_estimated_plot(
     *,
     figure_kwargs: dict = {},
     scatter_kwargs: dict = {},
-) -> plt.Figure:
+) -> Figure:
     """
     Plots a scatter plot of the estimated CATEs against the true CATEs.
 
@@ -154,27 +155,27 @@ def cate_true_vs_estimated_plot(
 
 
 def cate_line_plot(
-    estimated_cates: ArrayLike,
+    estimated_cates: np.ndarray,
     *,
-    true_cates: ArrayLike | None = None,
-    standard_errors: ArrayLike | None = None,
+    true_cates: np.ndarray | None = None,
+    standard_errors: np.ndarray | None = None,
     alpha: float = 0.05,
     window: int = 30,
     figure_kwargs: dict = {},
     line_kwargs: dict = {},
-) -> plt.Figure:
+) -> Figure:
     """
     Plots a line plot of the ordered estimated CATEs as a rolling mean with optional confidence intervals.
 
     Parameters
     ----------
-    estimated_cates : ArrayLike
+    estimated_cates : np.ndarray
         The estimated CATEs.
 
-    true_cates : ArrayLike | None
+    true_cates : np.ndarray | None
         The true CATEs.
 
-    standard_errors : ArrayLike | None
+    standard_errors : np.ndarray | None
         The standard errors of the estimated CATEs.
 
     alpha : float

--- a/caml/extensions/synthetic_data.py
+++ b/caml/extensions/synthetic_data.py
@@ -283,7 +283,7 @@ class SyntheticDataGenerator:
         assert np.allclose(f(design_matrix,params,noise), df['Y1_continuous'])
         ```
         """
-        return patsy.dmatrix(formula, data=df, return_type=return_type, **kwargs)
+        return patsy.dmatrix(formula, data=df, return_type=return_type, **kwargs)  # type: ignore
 
     def _generate_data(self):
         """
@@ -741,7 +741,7 @@ class SyntheticDataGenerator:
 
         if dep_type == "continuous":
 
-            def f_cont(x: pd.DataFrame, params: ArrayLike, noise: ArrayLike):
+            def f_cont(x: pd.DataFrame, params: np.ndarray, noise: ArrayLike):
                 """Continuous target function."""
                 return x @ params + noise
 
@@ -750,7 +750,7 @@ class SyntheticDataGenerator:
             dep = scores
         elif dep_type == "binary":
 
-            def f_binary(x: pd.DataFrame, params: ArrayLike, noise: ArrayLike):
+            def f_binary(x: pd.DataFrame, params: np.ndarray, noise: ArrayLike):
                 """Binary target function."""
                 raw = x @ params + noise
 
@@ -762,7 +762,7 @@ class SyntheticDataGenerator:
             dep = rng.binomial(1, scores)
         else:  # Discrete
 
-            def f_discrete(x: pd.DataFrame, params: ArrayLike, noise: ArrayLike):
+            def f_discrete(x: pd.DataFrame, params: np.ndarray, noise: ArrayLike):
                 """Discrete target function."""
                 raw = x @ params + noise
 
@@ -919,7 +919,7 @@ class SyntheticDataGenerator:
 
         cate_df = pd.DataFrame(dict_effects)
 
-        ate_df = cate_df.mean(axis=0).reset_index()
+        ate_df = cate_df.mean(axis=0).reset_index()  # pyright: ignore[reportAttributeAccessIssue]
         ate_df.columns = ["Treatment", "ATE"]
         ate_df["Treatment"] = ate_df["Treatment"].str.replace("CATE_of_", "")
 
@@ -1132,12 +1132,12 @@ def make_partially_linear_dataset_constant(
             "dgp must be 'make_plr_CCDDHNR2018' or 'make_plr_turrell2018'."
         )
 
-    df.columns = [c.replace("X", "W") for c in df.columns if "X" in c] + ["y", "d"]
+    df.columns = [c.replace("X", "W") for c in df.columns if "X" in c] + ["y", "d"]  # pyright: ignore[reportAttributeAccessIssue]
 
     true_ate = ate
     true_cates = np.full(n_obs, true_ate)
 
-    return df, true_cates, true_ate
+    return df, true_cates, true_ate  # pyright: ignore[reportReturnType]
 
 
 def make_fully_heterogeneous_dataset(
@@ -1256,7 +1256,7 @@ def make_fully_heterogeneous_dataset(
     y = y_func(d, x, theta)
 
     x_cols = [f"X{i + 1}" for i in np.arange(n_confounders)]
-    df = pd.DataFrame(np.column_stack((x, y, d)), columns=x_cols + ["y", "d"])
+    df = pd.DataFrame(np.column_stack((x, y, d)), columns=x_cols + ["y", "d"])  # pyright: ignore[reportArgumentType]
 
     d1 = np.ones_like(d)
     d0 = np.zeros_like(d)

--- a/caml/extensions/synthetic_data.py
+++ b/caml/extensions/synthetic_data.py
@@ -12,7 +12,6 @@ from numpy.typing import ArrayLike
 from scipy.linalg import toeplitz
 from scipy.special import expit as sigmoid
 from scipy.special import softmax
-from typeguard import typechecked
 
 from ..generics import experimental
 
@@ -54,7 +53,6 @@ def _truncate_and_renormalize_probabilities(
 
 
 @experimental
-@typechecked
 class SyntheticDataGenerator:
     r"""Generate highly flexible synthetic data for use in causal inference and CaML testing.
 
@@ -743,7 +741,6 @@ class SyntheticDataGenerator:
 
         if dep_type == "continuous":
 
-            @typechecked
             def f_cont(x: pd.DataFrame, params: ArrayLike, noise: ArrayLike):
                 """Continuous target function."""
                 return x @ params + noise
@@ -753,7 +750,6 @@ class SyntheticDataGenerator:
             dep = scores
         elif dep_type == "binary":
 
-            @typechecked
             def f_binary(x: pd.DataFrame, params: ArrayLike, noise: ArrayLike):
                 """Binary target function."""
                 raw = x @ params + noise
@@ -766,7 +762,6 @@ class SyntheticDataGenerator:
             dep = rng.binomial(1, scores)
         else:  # Discrete
 
-            @typechecked
             def f_discrete(x: pd.DataFrame, params: ArrayLike, noise: ArrayLike):
                 """Discrete target function."""
                 raw = x @ params + noise
@@ -931,7 +926,6 @@ class SyntheticDataGenerator:
         return cate_df, ate_df
 
 
-@typechecked
 def make_partially_linear_dataset_simple(
     n_obs: int = 1000,
     n_confounders: int = 5,
@@ -1038,7 +1032,6 @@ def make_partially_linear_dataset_simple(
     return df, true_cates, true_ate
 
 
-@typechecked
 def make_partially_linear_dataset_constant(
     n_obs: int = 1000,
     ate: float = 4.0,
@@ -1147,7 +1140,6 @@ def make_partially_linear_dataset_constant(
     return df, true_cates, true_ate
 
 
-@typechecked
 def make_fully_heterogeneous_dataset(
     n_obs: int = 1000,
     n_confounders: int = 5,

--- a/caml/generics.py
+++ b/caml/generics.py
@@ -1,6 +1,6 @@
 import timeit
 from functools import wraps
-from typing import Callable, Protocol, runtime_checkable
+from typing import Any, Callable, Protocol, runtime_checkable
 
 import pandas as pd
 
@@ -110,18 +110,18 @@ def maybe_jit(func: Callable | None = None, **jit_kwargs) -> Callable:
 
 
 @runtime_checkable
-class PandasConvertibleDataFrame(Protocol):
+class _PandasConvertibleDataFrame(Protocol):
     """Protocol for DataFrame-like objects that are pandas convertible.
 
     This includes DataFrames that are either pandas dataframes or can be converted to pandas via `to_pandas()` or `toPandas()` methods.
     """
 
-    @classmethod
-    def __subclasshook__(cls, subclass):
-        """Method to check if a class is a subclass of specs of PandasConvertibleDataFrame."""
-        if subclass is pd.DataFrame:
-            return True
+    to_pandas: Callable[..., Any]
+    toPandas: Callable[..., Any]
 
+    @classmethod
+    def __subclasshook__(cls, subclass: type) -> bool:
+        """Method to check if a class is a subclass of specs of PandasConvertibleDataFrame."""
         to_pandas = getattr(subclass, "to_pandas", None)
         toPandas = getattr(subclass, "toPandas", None)
 
@@ -129,6 +129,9 @@ class PandasConvertibleDataFrame(Protocol):
             return True
 
         return False
+
+
+PandasConvertibleDataFrame = pd.DataFrame | _PandasConvertibleDataFrame
 
 
 class FittedAttr:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 authors = [{ name = "Jacob Pieniazek", email = "jacob@pieniazek.me" }]
-maintainers = [{ name = "Jacob Pieniazek", email="jacob@pieniazek.me" }]
+maintainers = [{ name = "Jacob Pieniazek", email = "jacob@pieniazek.me" }]
 dependencies = [
     "econml>=0.15.1",
     "flaml[automl]>=2.2.0",
@@ -16,7 +16,13 @@ requires-python = ">= 3.10"
 version = "0.0.0-dev15"
 license = { text = "MIT" }
 readme = "README.md"
-keywords = ["causal inference", "econometrics", "machine learning", "automl", "heterogeneity"]
+keywords = [
+    "causal inference",
+    "econometrics",
+    "machine learning",
+    "automl",
+    "heterogeneity",
+]
 classifiers = [
     "Development Status :: 2 - Pre-Alpha",
     "Programming Language :: Python",
@@ -169,3 +175,4 @@ replace = 'version = "{new_version}"'
 [tool.pyright]
 venvPath = "."
 venv = ".venv"
+typeCheckingMode = "basic"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,6 @@ maintainers = [{ name = "Jacob Pieniazek", email = "jacob@pieniazek.me" }]
 dependencies = [
     "econml>=0.15.1",
     "flaml[automl]>=2.2.0",
-    "typeguard>=4.3.0",
     "doubleml>=0.8.0",
     "matplotlib>=3.9.2",
     "rich>=13.9.4",
@@ -49,6 +48,7 @@ test = [
     "pytest-cov>=5.0.0",
     "pytest-html>=4.1.1",
     "pytest-mock>=3.14.0",
+    "typeguard>=4.4.4",
 ]
 dev = [
     "anthropic>=0.42.0",
@@ -123,6 +123,9 @@ markers = [
     "extensions: mark tests for the extensions module",
     "synthetic_data: mark tests for the synthetic data module`",
 ]
+typeguard-packages = "caml"
+typeguard-collection-check-strategy = "ALL_ITEMS"
+typeguard-forward-ref-policy = "ERROR"
 
 [tool.coverage.run]
 omit = ["caml/logging.py", "caml/extensions/plots.py"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -176,3 +176,4 @@ replace = 'version = "{new_version}"'
 venvPath = "."
 venv = ".venv"
 typeCheckingMode = "basic"
+exclude = ["tests", "notebooks"]

--- a/tests/caml/extensions/test_synthetic_data.py
+++ b/tests/caml/extensions/test_synthetic_data.py
@@ -4,6 +4,7 @@ import numpy as np
 import pandas as pd
 import pytest
 from numpy.testing import assert_allclose
+from typeguard import suppress_type_checks
 from typing_extensions import Callable
 
 from caml.extensions.synthetic_data import (
@@ -18,6 +19,7 @@ pytestmark = [pytest.mark.extensions, pytest.mark.synthetic_data]
 
 
 class TestSyntheticDataGenerator:
+    @suppress_type_checks
     @pytest.mark.parametrize(
         (
             "n_obs,n_cont_outcomes,n_binary_outcomes,n_cont_treatments,n_binary_treatments,n_discrete_treatments,causal_model_functional_form,n_features"
@@ -141,13 +143,13 @@ class TestSyntheticDataGenerator:
                 function = dep_var_dgp["function"]
 
                 assert isinstance(dep_var_dgp, dict)
-                assert isinstance(formula, str | None)
+                assert isinstance(formula, str)
                 assert isinstance(params, np.ndarray)
                 assert isinstance(noise, np.ndarray)
                 assert isinstance(raw_scores, np.ndarray)
                 assert isinstance(function, Callable)
 
-                if formula is not None:
+                if formula != "":
                     design_matrix = gen.create_design_matrix(
                         gen.df, formula=formula, return_type="dataframe"
                     )

--- a/uv.lock
+++ b/uv.lock
@@ -262,7 +262,7 @@ wheels = [
 
 [[package]]
 name = "caml"
-version = "0.0.0.dev10"
+version = "0.0.0.dev15"
 source = { editable = "." }
 dependencies = [
     { name = "doubleml" },
@@ -271,7 +271,6 @@ dependencies = [
     { name = "matplotlib" },
     { name = "patsy" },
     { name = "rich" },
-    { name = "typeguard" },
 ]
 
 [package.optional-dependencies]
@@ -315,6 +314,7 @@ test = [
     { name = "pytest-cov" },
     { name = "pytest-html" },
     { name = "pytest-mock" },
+    { name = "typeguard" },
 ]
 
 [package.metadata]
@@ -333,7 +333,6 @@ requires-dist = [
     { name = "pyspark", marker = "extra == 'pyspark'", specifier = ">=3.5.2" },
     { name = "ray", marker = "extra == 'pyspark'", specifier = ">=2.35.0" },
     { name = "rich", specifier = ">=13.9.4" },
-    { name = "typeguard", specifier = ">=4.3.0" },
 ]
 provides-extras = ["pyspark", "polars", "jax", "jax-gpu"]
 
@@ -358,6 +357,7 @@ test = [
     { name = "pytest-cov", specifier = ">=5.0.0" },
     { name = "pytest-html", specifier = ">=4.1.1" },
     { name = "pytest-mock", specifier = ">=3.14.0" },
+    { name = "typeguard", specifier = ">=4.4.4" },
 ]
 
 [[package]]
@@ -4182,14 +4182,14 @@ wheels = [
 
 [[package]]
 name = "typeguard"
-version = "4.4.2"
+version = "4.4.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/70/60/8cd6a3d78d00ceeb2193c02b7ed08f063d5341ccdfb24df88e61f383048e/typeguard-4.4.2.tar.gz", hash = "sha256:a6f1065813e32ef365bc3b3f503af8a96f9dd4e0033a02c28c4a4983de8c6c49", size = 75746 }
+sdist = { url = "https://files.pythonhosted.org/packages/c7/68/71c1a15b5f65f40e91b65da23b8224dad41349894535a97f63a52e462196/typeguard-4.4.4.tar.gz", hash = "sha256:3a7fd2dffb705d4d0efaed4306a704c89b9dee850b688f060a8b1615a79e5f74", size = 75203 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cf/4b/9a77dc721aa0b7f74440a42e4ef6f9a4fae7324e17f64f88b96f4c25cc05/typeguard-4.4.2-py3-none-any.whl", hash = "sha256:77a78f11f09777aeae7fa08585f33b5f4ef0e7335af40005b0c422ed398ff48c", size = 35801 },
+    { url = "https://files.pythonhosted.org/packages/1b/a9/e3aee762739c1d7528da1c3e06d518503f8b6c439c35549b53735ba52ead/typeguard-4.4.4-py3-none-any.whl", hash = "sha256:b5f562281b6bfa1f5492470464730ef001646128b180769880468bd84b68b09e", size = 34874 },
 ]
 
 [[package]]
@@ -4203,11 +4203,11 @@ wheels = [
 
 [[package]]
 name = "typing-extensions"
-version = "4.13.2"
+version = "4.14.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/f6/37/23083fcd6e35492953e8d2aaaa68b860eb422b34627b13f2ce3eb6106061/typing_extensions-4.13.2.tar.gz", hash = "sha256:e6c81219bd689f51865d9e372991c540bda33a0379d5573cddb9a3a23f7caaef", size = 106967 }
+sdist = { url = "https://files.pythonhosted.org/packages/d1/bc/51647cd02527e87d05cb083ccc402f93e441606ff1f01739a62c8ad09ba5/typing_extensions-4.14.0.tar.gz", hash = "sha256:8676b788e32f02ab42d9e7c61324048ae4c6d844a399eebace3d4979d75ceef4", size = 107423 }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8b/54/b1ae86c0973cc6f0210b53d508ca3641fb6d0c56823f288d108bc7ab3cc8/typing_extensions-4.13.2-py3-none-any.whl", hash = "sha256:a439e7c04b49fec3e5d3e2beaa21755cadbbdc391694e28ccdd36ca4a1408f8c", size = 45806 },
+    { url = "https://files.pythonhosted.org/packages/69/e0/552843e0d356fbb5256d21449fa957fa4eff3bbc135a74a691ee70c7c5da/typing_extensions-4.14.0-py3-none-any.whl", hash = "sha256:a1514509136dd0b477638fc68d6a91497af5076466ad0fa6c338e44e359944af", size = 43839 },
 ]
 
 [[package]]


### PR DESCRIPTION
## Why
- Disable typeguard during runtime in favor of static typing (pyright) and type checking (typeguard) during tests only

## Description
- Reconciled all pyright errors, except for in `cate.py` 
- Added pyright pre-commit hook 
- Removed typeguard during runtime in favor of only implementing during tests  

## Other Notes
- Major refactor on `cate.py` following, so fixing pyright errors deferred until that PR
