### PR TITLE
ci: add codecov workflow 

### DIFF
--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -22,8 +22,9 @@ jobs:
       - name: Run tests
         run: uv run pytest tests
 
-      - name: Run codacy-coverage-reporter
-        uses: codacy/codacy-coverage-reporter-action@89d6c85cfafaec52c72b6c5e8b2878d33104c699
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v5
         with:
-          project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
-          coverage-reports: tests/reports/coverage.xml
+          directory: ./tests/reports
+          token: ${{ secrets.CODECOV_TOKEN }}
+          slug: jakepenzak/caml

--- a/.github/workflows/codecov.yml
+++ b/.github/workflows/codecov.yml
@@ -22,9 +22,15 @@ jobs:
       - name: Run tests
         run: uv run pytest tests
 
-      - name: Upload coverage reports to Codecov
-        uses: codecov/codecov-action@v5
+      - name: Run codecov-action
+        uses: codecov/codecov-action@18283e04ce6e62d37312384ff67231eb8fd56d24
         with:
           directory: ./tests/reports
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: jakepenzak/caml
+
+      - name: Run codacy-coverage-reporter
+        uses: codacy/codacy-coverage-reporter-action@89d6c85cfafaec52c72b6c5e8b2878d33104c699
+        with:
+          project-token: ${{ secrets.CODACY_PROJECT_TOKEN }}
+          coverage-reports: tests/reports/coverage.xml

--- a/README.md
+++ b/README.md
@@ -17,7 +17,6 @@
 [![Pre-Commit & Linting Checks](https://github.com/jakepenzak/caml/actions/workflows/lint.yml/badge.svg?branch=main)](https://github.com/jakepenzak/caml/actions/workflows/lint.yml)
 <br>
 [![Codacy Badge](https://app.codacy.com/project/badge/Grade/cd6cc54c704e4a7aafe20f851bc39236)](https://app.codacy.com/gh/jakepenzak/caml/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_grade)
-[![Codacy Badge](https://app.codacy.com/project/badge/Coverage/cd6cc54c704e4a7aafe20f851bc39236)](https://app.codacy.com/gh/jakepenzak/caml/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_coverage)
 
 **Ca**usal **M**achine **L**earning
 

--- a/docs/index.qmd
+++ b/docs/index.qmd
@@ -13,7 +13,6 @@
 [![Pre-Commit & Linting Checks](https://github.com/jakepenzak/caml/actions/workflows/lint.yml/badge.svg?branch=main)](https://github.com/jakepenzak/caml/actions/workflows/lint.yml)
 <br>
 <a href="https://app.codacy.com/gh/jakepenzak/caml/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_grade"><img src="https://app.codacy.com/project/badge/Grade/cd6cc54c704e4a7aafe20f851bc39236"/></a>
-<a href="https://app.codacy.com/gh/jakepenzak/caml/dashboard?utm_source=gh&utm_medium=referral&utm_content=&utm_campaign=Badge_coverage"><img src="https://app.codacy.com/project/badge/Coverage/cd6cc54c704e4a7aafe20f851bc39236"/></a>
 
 **Ca**usal **M**achine **L**earning
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,7 +116,7 @@ convention = "numpy"
 
 [tool.pytest.ini_options]
 filterwarnings = "ignore::DeprecationWarning"
-addopts = "--cov=caml/ --cov-report=term-missing --cov-report=html:tests/reports/htmlcov --cov-report=xml:tests/reports/coverage.xml"
+addopts = "--cov=caml/ --cov-branch --cov-report=term-missing --cov-report=html:tests/reports/htmlcov --cov-report=xml:tests/reports/coverage.xml"
 markers = [
     "ols: mark tests for the FastOLS/ols module",
     "core: mark tests for the core module",


### PR DESCRIPTION
## Why

- Add [codecov](https://about.codecov.io/) for coverage analysis alongside [codacy](https://www.codacy.com/) for static analysis

## Description

- Add codecov action to `codecov.yml` 
- Temporarily use alongside codacy coverage report as well
 
## Other Notes
- N/A
