### PR TITLE
fix: add bump-my-version to release gha

### DIFF
--- a/.github/workflows/create_release_tag_and_docs.yml
+++ b/.github/workflows/create_release_tag_and_docs.yml
@@ -30,7 +30,9 @@ jobs:
           version: ${{ vars.UV_VERSION }}
 
       - name: Create environment
-        run: uv sync --all-groups --frozen
+        run: |
+          uv sync --all-groups --frozen
+          uv pip install bump-my-version==0.29.0
 
       - name: Get Current Version
         id: get_version


### PR DESCRIPTION
## Why
- Fix small issue in release tag & docs GHA with missing `bump-my-version` dependency

## Description
- Added dependency to GHA

## Other Notes
- N/A
